### PR TITLE
fix: hashValue error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+* Add option to set a `colorScheme` for the map (system, light, dark)
+
 ## 1.3.0
 
 * Animate marker position changes instead of removing and re-adding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1
+
+* Fixes errors related to `Error: The method 'hashValues' isn't defined for`
+
 ## 1.4.0
 
 * Add option to set a `colorScheme` for the map (system, light, dark)

--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -43,6 +43,7 @@ class MapUiBodyState extends State<MapUiBody> {
   bool _myLocationButtonEnabled = true;
   MinMaxZoomPreference _minMaxZoomPreference = MinMaxZoomPreference.unbounded;
   MapType _mapType = MapType.standard;
+  MapColorScheme _colorScheme = MapColorScheme.system;
   bool _rotateGesturesEnabled = true;
   bool _scrollGesturesEnabled = true;
   bool _pitchGesturesEnabled = true;
@@ -96,6 +97,18 @@ class MapUiBodyState extends State<MapUiBody> {
         });
       },
     );
+  }
+
+  Widget _colorSchemeCycler() {
+    final MapColorScheme nextScheme = MapColorScheme
+        .values[(_colorScheme.index + 1) % MapColorScheme.values.length];
+    return TextButton(
+        child: Text('change color scheme to $nextScheme'),
+        onPressed: () {
+          setState(() {
+            _colorScheme = nextScheme;
+          });
+        });
   }
 
   Widget _rotateToggler() {
@@ -170,6 +183,7 @@ class MapUiBodyState extends State<MapUiBody> {
   Widget build(BuildContext context) {
     final AppleMap appleMap = AppleMap(
       onMapCreated: onMapCreated,
+      colorScheme: _colorScheme,
       trackingMode: _trackingMode,
       initialCameraPosition: _kInitialPosition,
       compassEnabled: _compassEnabled,
@@ -207,6 +221,7 @@ class MapUiBodyState extends State<MapUiBody> {
                 children: <Widget>[
                   _compassToggler(),
                   _mapTypeCycler(),
+                  _colorSchemeCycler(),
                   _zoomBoundsToggler(),
                   _rotateToggler(),
                   _scrollToggler(),

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -20,7 +20,6 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
     var oldBounds: CGRect?
     var options: Dictionary<String, Any>?
     var isMyLocationButtonShowing: Bool? = false
-    var mapStyle: Int? = 0
     
     fileprivate let locationManager: CLLocationManager = CLLocationManager()
     

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -20,6 +20,7 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
     var oldBounds: CGRect?
     var options: Dictionary<String, Any>?
     var isMyLocationButtonShowing: Bool? = false
+    var mapStyle: Int? = 0
     
     fileprivate let locationManager: CLLocationManager = CLLocationManager()
     
@@ -143,6 +144,14 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
         
         if let mapType: Int = options["mapType"] as? Int {
             self.mapType = self.mapTypes[mapType]
+        }
+
+        if let mapStyle: Int = options["mapStyle"] as? Int {
+            if #available(iOS 13.0, *) {
+                if mapStyle != 0 {
+                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mapStyle) ?? .unspecified
+                }
+            }
         }
         
         if let trafficEnabled: Bool = options["trafficEnabled"] as? Bool {

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -145,10 +145,10 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
             self.mapType = self.mapTypes[mapType]
         }
 
-        if let mapStyle: Int = options["mapStyle"] as? Int {
+        if let colorScheme: Int = options["colorScheme"] as? Int {
             if #available(iOS 13.0, *) {
-                if mapStyle != 0 {
-                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mapStyle) ?? .unspecified
+                if colorScheme != 0 {
+                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: colorScheme) ?? .unspecified
                 }
             }
         }

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -147,9 +147,7 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
 
         if let colorScheme: Int = options["colorScheme"] as? Int {
             if #available(iOS 13.0, *) {
-                if colorScheme != 0 {
-                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: colorScheme) ?? .unspecified
-                }
+                self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: colorScheme) ?? .unspecified
             }
         }
         

--- a/lib/src/annotation.dart
+++ b/lib/src/annotation.dart
@@ -89,7 +89,7 @@ class InfoWindow {
   }
 
   @override
-  int get hashCode => hashValues(title.hashCode, snippet, anchor);
+  int get hashCode => Object.hash(title.hashCode, snippet, anchor);
 
   @override
   String toString() {

--- a/lib/src/annotation_updates.dart
+++ b/lib/src/annotation_updates.dart
@@ -87,7 +87,7 @@ class _AnnotationUpdates {
 
   @override
   int get hashCode =>
-      hashValues(annotationsToAdd, annotationIdsToRemove, annotationsToChange);
+      Object.hash(annotationsToAdd, annotationIdsToRemove, annotationsToChange);
 
   @override
   String toString() {

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -192,7 +192,7 @@ class _AppleMapState extends State<AppleMap> {
   Widget build(BuildContext context) {
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition._toMap(),
-      'options': _appleMapOptions.toMap(),
+      'options': _appleMapOptions.toMap(context: context),
       'annotationsToAdd': _serializeAnnotationSet(widget.annotations),
       'polylinesToAdd': _serializePolylineSet(widget.polylines),
       'polygonsToAdd': _serializePolygonSet(widget.polygons),
@@ -396,7 +396,7 @@ class _AppleMapOptions {
 
   final bool? insetsLayoutMarginsFromSafeArea;
 
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> toMap({BuildContext? context}) {
     final Map<String, dynamic> optionsMap = <String, dynamic>{};
 
     void addIfNonNull(String fieldName, dynamic value) {
@@ -405,10 +405,22 @@ class _AppleMapOptions {
       }
     }
 
+    if (context != null) {
+      final systemScheme = Theme.of(context).brightness == Brightness.dark
+          ? MapColorScheme.dark
+          : MapColorScheme.light;
+      addIfNonNull(
+          'colorScheme',
+          colorScheme == MapColorScheme.system
+              ? systemScheme.index
+              : colorScheme?.index);
+    } else {
+      addIfNonNull('colorScheme', colorScheme?.index);
+    }
+
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('trafficEnabled', trafficEnabled);
     addIfNonNull('mapType', mapType?.index);
-    addIfNonNull('colorScheme', colorScheme?.index);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?._toJson());
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);
     addIfNonNull('scrollGesturesEnabled', scrollGesturesEnabled);

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -23,7 +23,7 @@ class AppleMap extends StatefulWidget {
     this.compassEnabled = true,
     this.trafficEnabled = false,
     this.mapType = MapType.standard,
-    this.mapStyle = MapStyle.system,
+    this.colorScheme = MapColorScheme.system,
     this.minMaxZoomPreference = MinMaxZoomPreference.unbounded,
     this.trackingMode = TrackingMode.none,
     this.rotateGesturesEnabled = true,
@@ -60,8 +60,8 @@ class AppleMap extends StatefulWidget {
   /// Type of map tiles to be rendered.
   final MapType mapType;
 
-  /// TODO
-  final MapStyle mapStyle;
+  /// Color scheme for the standard map to use.
+  final MapColorScheme colorScheme;
 
   /// The mode used to track the user location.
   final TrackingMode trackingMode;
@@ -336,7 +336,7 @@ class _AppleMapOptions {
     this.compassEnabled,
     this.trafficEnabled,
     this.mapType,
-    this.mapStyle,
+    this.colorScheme,
     this.minMaxZoomPreference,
     this.rotateGesturesEnabled,
     this.scrollGesturesEnabled,
@@ -354,7 +354,7 @@ class _AppleMapOptions {
       compassEnabled: map.compassEnabled,
       trafficEnabled: map.trafficEnabled,
       mapType: map.mapType,
-      mapStyle: map.mapStyle,
+      colorScheme: map.colorScheme,
       minMaxZoomPreference: map.minMaxZoomPreference,
       rotateGesturesEnabled: map.rotateGesturesEnabled,
       scrollGesturesEnabled: map.scrollGesturesEnabled,
@@ -374,7 +374,7 @@ class _AppleMapOptions {
 
   final MapType? mapType;
 
-  final MapStyle? mapStyle;
+  final MapColorScheme? colorScheme;
 
   final MinMaxZoomPreference? minMaxZoomPreference;
 
@@ -408,7 +408,7 @@ class _AppleMapOptions {
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('trafficEnabled', trafficEnabled);
     addIfNonNull('mapType', mapType?.index);
-    addIfNonNull('mapStyle', mapStyle?.index);
+    addIfNonNull('colorScheme', colorScheme?.index);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?._toJson());
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);
     addIfNonNull('scrollGesturesEnabled', scrollGesturesEnabled);

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -23,6 +23,7 @@ class AppleMap extends StatefulWidget {
     this.compassEnabled = true,
     this.trafficEnabled = false,
     this.mapType = MapType.standard,
+    this.mapStyle = MapStyle.system,
     this.minMaxZoomPreference = MinMaxZoomPreference.unbounded,
     this.trackingMode = TrackingMode.none,
     this.rotateGesturesEnabled = true,
@@ -58,6 +59,9 @@ class AppleMap extends StatefulWidget {
 
   /// Type of map tiles to be rendered.
   final MapType mapType;
+
+  /// TODO
+  final MapStyle mapStyle;
 
   /// The mode used to track the user location.
   final TrackingMode trackingMode;
@@ -332,6 +336,7 @@ class _AppleMapOptions {
     this.compassEnabled,
     this.trafficEnabled,
     this.mapType,
+    this.mapStyle,
     this.minMaxZoomPreference,
     this.rotateGesturesEnabled,
     this.scrollGesturesEnabled,
@@ -349,6 +354,7 @@ class _AppleMapOptions {
       compassEnabled: map.compassEnabled,
       trafficEnabled: map.trafficEnabled,
       mapType: map.mapType,
+      mapStyle: map.mapStyle,
       minMaxZoomPreference: map.minMaxZoomPreference,
       rotateGesturesEnabled: map.rotateGesturesEnabled,
       scrollGesturesEnabled: map.scrollGesturesEnabled,
@@ -367,6 +373,8 @@ class _AppleMapOptions {
   final bool? trafficEnabled;
 
   final MapType? mapType;
+
+  final MapStyle? mapStyle;
 
   final MinMaxZoomPreference? minMaxZoomPreference;
 
@@ -400,6 +408,7 @@ class _AppleMapOptions {
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('trafficEnabled', trafficEnabled);
     addIfNonNull('mapType', mapType?.index);
+    addIfNonNull('mapStyle', mapStyle?.index);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?._toJson());
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);
     addIfNonNull('scrollGesturesEnabled', scrollGesturesEnabled);

--- a/lib/src/camera.dart
+++ b/lib/src/camera.dart
@@ -73,7 +73,7 @@ class CameraPosition {
   }
 
   @override
-  int get hashCode => hashValues(heading, target, pitch, zoom);
+  int get hashCode => Object.hash(heading, target, pitch, zoom);
 
   @override
   String toString() =>

--- a/lib/src/circle_updates.dart
+++ b/lib/src/circle_updates.dart
@@ -87,7 +87,7 @@ class _CircleUpdates {
 
   @override
   int get hashCode =>
-      hashValues(circlesToAdd, circleIdsToRemove, circlesToChange);
+      Object.hash(circlesToAdd, circleIdsToRemove, circlesToChange);
 
   @override
   String toString() {

--- a/lib/src/location.dart
+++ b/lib/src/location.dart
@@ -44,7 +44,7 @@ class LatLng {
   }
 
   @override
-  int get hashCode => hashValues(latitude, longitude);
+  int get hashCode => Object.hash(latitude, longitude);
 }
 
 /// A latitude/longitude aligned rectangle.
@@ -116,5 +116,5 @@ class LatLngBounds {
   }
 
   @override
-  int get hashCode => hashValues(southwest, northeast);
+  int get hashCode => Object.hash(southwest, northeast);
 }

--- a/lib/src/polygon_updates.dart
+++ b/lib/src/polygon_updates.dart
@@ -87,7 +87,7 @@ class _PolygonUpdates {
 
   @override
   int get hashCode =>
-      hashValues(polygonsToAdd, polygonIdsToRemove, polygonsToChange);
+      Object.hash(polygonsToAdd, polygonIdsToRemove, polygonsToChange);
 
   @override
   String toString() {

--- a/lib/src/polyline_updates.dart
+++ b/lib/src/polyline_updates.dart
@@ -81,7 +81,7 @@ class _PolylineUpdates {
 
   @override
   int get hashCode =>
-      hashValues(polylinesToAdd, polylineIdsToRemove, polylinesToChange);
+      Object.hash(polylinesToAdd, polylineIdsToRemove, polylinesToChange);
 
   @override
   String toString() {

--- a/lib/src/snapshot_options.dart
+++ b/lib/src/snapshot_options.dart
@@ -45,7 +45,7 @@ class SnapshotOptions {
   }
 
   @override
-  int get hashCode => hashValues(showBuildings, showPointsOfInterest);
+  int get hashCode => Object.hash(showBuildings, showPointsOfInterest);
 
   @override
   String toString() =>

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -16,7 +16,7 @@ enum MapType {
   hybrid,
 }
 
-enum MapStyle {
+enum MapColorScheme {
   /// Follow system style
   system,
   

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -16,6 +16,14 @@ enum MapType {
   hybrid,
 }
 
+enum MapStyle {
+  /// Follow system style
+  system,
+  
+  light, 
+  dark,
+}
+
 enum TrackingMode {
   // the user's location is not followed
   none,

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -19,8 +19,8 @@ enum MapType {
 enum MapColorScheme {
   /// Follow system style
   system,
-  
-  light, 
+
+  light,
   dark,
 }
 

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -80,8 +80,7 @@ class MinMaxZoomPreference {
   final double? maxZoom;
 
   /// Unbounded zooming.
-  static const MinMaxZoomPreference unbounded =
-      MinMaxZoomPreference(null, null);
+  static const MinMaxZoomPreference unbounded = MinMaxZoomPreference(null, null);
 
   dynamic _toJson() => <dynamic>[minZoom, maxZoom];
 
@@ -94,7 +93,7 @@ class MinMaxZoomPreference {
   }
 
   @override
-  int get hashCode => hashValues(minZoom, maxZoom);
+  int get hashCode => Object.hash(minZoom, maxZoom);
 
   @override
   String toString() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apple_maps_flutter
 description: This plugin uses the Flutter platform view to display an Apple Maps widget.
-version: 1.3.0
+version: 1.4.0
 homepage: https://luisthein.de
 repository: https://github.com/LuisThein/apple_maps_flutter
 issue_tracker: https://github.com/LuisThein/apple_maps_flutter/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apple_maps_flutter
 description: This plugin uses the Flutter platform view to display an Apple Maps widget.
-version: 1.4.0
+version: 1.4.1
 homepage: https://luisthein.de
 repository: https://github.com/LuisThein/apple_maps_flutter
 issue_tracker: https://github.com/LuisThein/apple_maps_flutter/issues


### PR DESCRIPTION
This PR fixes an issue with the new Flutter version that gives an error when building the app. The message may look similar to `Error: The method 'hashValues' isn't defined for x`. 

## Pre-launch Checklist

- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making if a test is possible.
- [x] All existing and new tests are passing.